### PR TITLE
Add benchmark test for sharded map

### DIFF
--- a/vertical-sharding/go.mod
+++ b/vertical-sharding/go.mod
@@ -1,3 +1,3 @@
 module github.com/matinkhosravani/cloud-native-go-book-notes/vertical-sharding
 
-go 1.21.1
+go 1.21

--- a/vertical-sharding/sharded/sharded_bench_test.go
+++ b/vertical-sharding/sharded/sharded_bench_test.go
@@ -1,0 +1,28 @@
+package sharded
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkShardedMap(b *testing.B) {
+	for _, shards := range []int{1, 4, 16, 64, 256} {
+		for _, concurrency := range []int{1, 16, 256} {
+			runTest(b, shards, concurrency)
+		}
+	}
+}
+
+func runTest(b *testing.B, shards, concurrency int) {
+	shardedMap := NewShardedMap(shards)
+	b.SetParallelism(concurrency)
+	b.Run(fmt.Sprintf(`sharded-%d-%d`, shards, concurrency), func(b *testing.B) {
+		b.RunParallel(func(pb *testing.PB) {
+			o := rand.Intn(1e6)
+			for i := 0; pb.Next(); i++ {
+				shardedMap.Set(fmt.Sprintf("key%d", i+o), i)
+			}
+		})
+	})
+}


### PR DESCRIPTION
Adds multi-dimensional benchmark illustrating relationship between shard count, concurrency and performance.
```
> go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/matinkhosravani/cloud-native-go-book-notes/vertical-sharding/sharded
cpu: 11th Gen Intel(R) Core(TM) i9-11900H @ 2.50GHz
BenchmarkShardedMap/sharded-1-1-16               2256750               501.7 ns/op
BenchmarkShardedMap/sharded-1-16-16              2523734               476.8 ns/op
BenchmarkShardedMap/sharded-1-256-16             2525878               475.1 ns/op
BenchmarkShardedMap/sharded-4-1-16               5136452               199.9 ns/op
BenchmarkShardedMap/sharded-4-16-16              5449748               201.0 ns/op
BenchmarkShardedMap/sharded-4-256-16             5430946               205.3 ns/op
BenchmarkShardedMap/sharded-16-1-16             12768838               104.4 ns/op
BenchmarkShardedMap/sharded-16-16-16            11100850               101.0 ns/op
BenchmarkShardedMap/sharded-16-256-16           10994262                95.04 ns/op
BenchmarkShardedMap/sharded-64-1-16             14047240                78.52 ns/op
BenchmarkShardedMap/sharded-64-16-16            13692243                81.71 ns/op
BenchmarkShardedMap/sharded-64-256-16           13546132                80.48 ns/op
BenchmarkShardedMap/sharded-256-1-16            14893131                69.72 ns/op
BenchmarkShardedMap/sharded-256-16-16           15349326                68.39 ns/op
BenchmarkShardedMap/sharded-256-256-16          17416581                63.46 ns/op
PASS
ok      github.com/matinkhosravani/cloud-native-go-book-notes/vertical-sharding/sharded 22.431s
```